### PR TITLE
Add support for binary XOR with positive numbers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,8 @@ these differences:
 
 - Bignum rounds towards zero for integer divisions, e.g. `10 / -3 = -3`, whereas bigint
   rounds towards negative infinity, e.g. `10 / -3 = -4`.
-- Boolean operations (and, or, xor) are not supported.
+- Boolean operations (and, or) are not supported. Boolean xor is implemented
+  for positive numbers only.
 - nextPrime() is not supported.
 - sqrt() and root() are not supported.
 
@@ -32,7 +33,7 @@ simple.js
 ---------
 
     var bignum = require('bignum');
-    
+
     var b = bignum('782910138827292261791972728324982')
         .sub('182373273283402171237474774728373')
         .div(8)

--- a/test/big.js
+++ b/test/big.js
@@ -302,10 +302,11 @@ exports.or = function () {
         }
     }
 };
+*/
 
 exports.xor = function () {
-    for (var i = -10; i < 10; i++) {
-        for (var j = -10; j < 10; j++) {
+    for (var i = 0; i < 256; i++) {
+        for (var j = 0; j < 256; j++) {
             var is = i.toString();
             var js = j.toString();
             var ks = (i ^ j).toString();
@@ -316,7 +317,6 @@ exports.xor = function () {
         }
     }
 };
-*/
 
 exports.rand = function () {
     for (var i = 1; i < 1000; i++) {


### PR DESCRIPTION
Implements XOR for positive numbers. Negative numbers are not supported because `BN_bn2bin` converts to a positive big-endian byte array and `BN_bn2mpi` are not yet available in the node version of OpenSSL.
