### PR TITLE
Added gcd and bitLength methods

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -268,16 +268,27 @@ Return a new `bignum` that is the square root. This truncates.
 Return a new `bignum` that is the `nth` root. This truncates.
 
 .shiftLeft(n)
--------
+-------------
 
-Return a new `bignum` that is the `2^n` multiple. Equivalent of the <<
+Return a new `bignum` that is the `2^n` multiple. Equivalent of the `<<`
 operator.
 
 .shiftRight(n)
--------
+--------------
 
 Return a new `bignum` of the value integer divided by
-`2^n`. Equivalent of the >> operator.
+`2^n`. Equivalent of the `>>` operator.
+
+.gcd(n)
+-------
+
+Return the greatest common divisor of the current `bignum` with `n` as a new
+`bignum`.
+
+.bitLength()
+------------
+
+Return the number of bits used to represent the current `bignum`.
 
 install
 =======

--- a/bignum.cc
+++ b/bignum.cc
@@ -129,6 +129,8 @@ protected:
   static Handle<Value> Binvertm(const Arguments& args);
   static Handle<Value> Bsqrt(const Arguments& args);
   static Handle<Value> Broot(const Arguments& args);
+  static Handle<Value> BitLength(const Arguments& args);
+  static Handle<Value> Bgcd(const Arguments& args);
 };
 
 Persistent<FunctionTemplate> BigNum::constructor_template;
@@ -177,6 +179,8 @@ void BigNum::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "binvertm", Binvertm);
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "bsqrt", Bsqrt);
   NODE_SET_PROTOTYPE_METHOD(constructor_template, "broot", Broot);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "bitLength", BitLength);
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, "gcd", Bgcd);
 
   target->Set(String::NewSymbol("BigNum"), constructor_template->GetFunction());
 }
@@ -788,6 +792,34 @@ BigNum::Broot(const Arguments& args)
   HandleScope scope;
 
   return ThrowException(Exception::Error(String::New("root is not supported by OpenSSL.")));
+}
+
+Handle<Value>
+BigNum::BitLength(const Arguments& args)
+{
+  BigNum *bignum = ObjectWrap::Unwrap<BigNum>(args.This());
+  HandleScope scope;
+  
+  int size = BN_num_bits(&bignum->bignum_);
+  Handle<Value> result = Integer::New(size);
+  
+  return scope.Close(result);
+}
+
+Handle<Value>
+BigNum::Bgcd(const Arguments& args)
+{
+  AutoBN_CTX ctx;
+  BigNum *bignum = ObjectWrap::Unwrap<BigNum>(args.This());
+  HandleScope scope;
+
+  BigNum *bi = ObjectWrap::Unwrap<BigNum>(args[0]->ToObject());
+  BigNum *res = new BigNum();
+
+  BN_gcd(&res->bignum_, &bignum->bignum_, &bi->bignum_, ctx);
+
+  WRAP_RESULT(res, result);
+  return scope.Close(result);
 }
 
 static Handle<Value>

--- a/test/big.js
+++ b/test/big.js
@@ -425,18 +425,35 @@ exports.mod = function () {
 };
 
 exports.endian = function () {
-  var a = bignum(0x0102030405);
-  assert.eql(a.toBuffer({ endian: 'big', size: 2 }).toString('hex'), '000102030405');
-  assert.eql(a.toBuffer({ endian: 'little', size: 2 }).toString('hex'), '010003020504');
+    var a = bignum(0x0102030405);
+    assert.eql(a.toBuffer({ endian: 'big', size: 2 }).toString('hex'), '000102030405');
+    assert.eql(a.toBuffer({ endian: 'little', size: 2 }).toString('hex'), '010003020504');
+    
+    var b = bignum(0x0102030405);
+    assert.eql(a.toBuffer({ endian: 'big', size: 'auto' }).toString('hex'), '0102030405');
+    assert.eql(a.toBuffer({ endian: 'little', size: 'auto' }).toString('hex'), '0504030201');
+    
+    var c = new Buffer("000102030405", 'hex');
+    assert.eql(bignum.fromBuffer(c, { endian: 'big', size: 'auto'}).toString(16), "0102030405");
+    assert.eql(bignum.fromBuffer(c, { endian: 'little', size: 'auto'}).toString(16), "050403020100");
+};
 
-  var b = bignum(0x0102030405);
-  assert.eql(a.toBuffer({ endian: 'big', size: 'auto' }).toString('hex'), '0102030405');
-  assert.eql(a.toBuffer({ endian: 'little', size: 'auto' }).toString('hex'), '0504030201');
+exports.bitlength = function () {
+    var bl = bignum(
+    '433593290010590489671135819286259593426549306666324008679782084292'
+      + '2446494189019075159822930571858728009485237489829138626896756141'
+      + '873895833763224917704497568647701157104426'
+    ).bitLength();
+    
+    assert.equal(bl > 0, true);
+};
 
-  var c = new Buffer("000102030405", 'hex');
-  assert.eql(bignum.fromBuffer(c, { endian: 'big', size: 'auto'}).toString(16), "0102030405");
-  assert.eql(bignum.fromBuffer(c, { endian: 'little', size: 'auto'}).toString(16), "050403020100");
-}
+exports.gcd = function () {
+    var b1 = bignum('234897235923342343242');
+    var b2 = bignum('234790237101762305340234');
+    var expected = bignum('6');
+    assert.equal(b1.gcd(b2).toString(), expected.toString());
+};
 
 if (process.argv[1] === __filename) {
     assert.eql = assert.deepEqual;


### PR DESCRIPTION
These were [added by node-bigint](https://github.com/substack/node-bigint/pull/15) some time ago, and I needed them.
