### PR TITLE
fix for v0.10.1

### DIFF
--- a/bignum.cc
+++ b/bignum.cc
@@ -808,3 +808,5 @@ init (Handle<Object> target)
   BigNum::Initialize(target);
   NODE_SET_METHOD(target, "setJSConditioner", SetJSConditioner);
 }
+
+NODE_MODULE(bignum, init)


### PR DESCRIPTION
This fixes the error message "Error: Symbol bignum_module not found." on node v0.10.

Also described here: https://github.com/justmoon/node-bignum/issues/11#issuecomment-15291751
