### PR TITLE
Adding Windows compilation support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,9 @@
 
         # For Windows, require either a 32-bit or 64-bit
         # separately-compiled OpenSSL library.
+	# Currently set up to use with the following OpenSSL distro:
+	#
+	# http://slproweb.com/products/Win32OpenSSL.html
         [
 	  'OS=="win"', 
 	  {


### PR DESCRIPTION
justmoon,

I would like to add Windows and ARM compilation support to binding.gyp.  I am trying to enable Windows-based Node developers in my organization to be able to develop and run continuous integration on software that involves the "vault" node plugin.

As you are probably aware, Node 0.10.x Windows distributions do not expose the embedded OpenSSL.  An exterior linked OpenSSL must be available for Windows to compile OpenSSL-based extensions.

Regards,
Chris Vaughan
