### PR TITLE
BigNum.isBigNum via feature detection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,6 +113,11 @@ bignum.prime(bits, safe=true)
 
 Generate a probable prime of length `bits`. If `safe` is true, it will be a "safe" prime of the form p=2p'+1 where p' is also prime.
 
+bignum.isBigNum(num)
+-----------------------------
+
+Return true if `num` is identified as a bignum instance. Otherwise, return false.
+
 methods[1]
 ==========
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ BigNum.conditionArgs = function(num, base) {
 
 cc.setJSConditioner(BigNum.conditionArgs);
 
+BigNum.isBigNum = function(num) {
+    return Boolean(num && num.badd && num.bsub && num.bmul && num.bdiv && num.bmod);
+};
+
 BigNum.prototype.inspect = function () {
     return '<BigNum ' + this.toString(10) + '>';
 };
@@ -70,7 +74,7 @@ BigNum.prototype.toNumber = function () {
 
 [ 'add', 'sub', 'mul', 'div', 'mod' ].forEach(function (op) {
     BigNum.prototype[op] = function (num) {
-        if (num instanceof BigNum) {
+        if (BigNum.isBigNum(num)) {
             return this['b'+op](num);
         }
         else if (typeof num === 'number') {
@@ -113,7 +117,7 @@ BigNum.prototype.powm = function (num, mod) {
     if ((typeof mod) === 'number' || (typeof mod) === 'string') {
         m = BigNum(mod);
     }
-    else if (mod instanceof BigNum) {
+    else if (BigNum.isBigNum(mod)) {
         m = mod;
     }
 
@@ -124,7 +128,7 @@ BigNum.prototype.powm = function (num, mod) {
         var n = BigNum(num);
         return this.bpowm(n, m);
     }
-    else if (num instanceof BigNum) {
+    else if (BigNum.isBigNum(num)) {
         return this.bpowm(num, m);
     }
 };
@@ -135,7 +139,7 @@ BigNum.prototype.mod = function (num, mod) {
     if ((typeof mod) === 'number' || (typeof mod) === 'string') {
         m = BigNum(mod);
     }
-    else if (mod instanceof BigNum) {
+    else if (BigNum.isBigNum(mod)) {
         m = mod;
     }
 
@@ -146,7 +150,7 @@ BigNum.prototype.mod = function (num, mod) {
         var n = BigNum(num);
         return this.bmod(n, m);
     }
-    else if (num instanceof BigNum) {
+    else if (BigNum.isBigNum(num)) {
         return this.bmod(num, m);
     }
 };
@@ -198,7 +202,7 @@ BigNum.prototype.shiftRight = function (num) {
 };
 
 BigNum.prototype.cmp = function (num) {
-    if (num instanceof BigNum) {
+    if (BigNum.isBigNum(num)) {
         return this.bcompare(num);
     }
     else if (typeof num === 'number') {
@@ -241,7 +245,7 @@ BigNum.prototype.le = function (num) {
 
 'and or xor'.split(' ').forEach(function (name) {
     BigNum.prototype[name] = function (num) {
-        if (num instanceof BigNum) {
+        if (BigNum.isBigNum(num)) {
             return this['b' + name](num);
         }
         else {
@@ -256,7 +260,7 @@ BigNum.prototype.sqrt = function() {
 };
 
 BigNum.prototype.root = function(num) {
-    if (num instanceof BigNum) {
+    if (BigNum.isBigNum(num)) {
         return this.broot(num);
     }
     else {
@@ -275,7 +279,7 @@ BigNum.prototype.rand = function (to) {
         }
     }
     else {
-        var x = to instanceof BigNum
+        var x = BigNum.isBigNum(to)
             ? to.sub(this)
             : BigNum(to).sub(this);
         return x.brand0().add(this);
@@ -283,7 +287,7 @@ BigNum.prototype.rand = function (to) {
 };
 
 BigNum.prototype.invertm = function (mod) {
-    if (mod instanceof BigNum) {
+    if (BigNum.isBigNum(mod)) {
         return this.binvertm(mod);
     }
     else {
@@ -426,7 +430,7 @@ Object.keys(BigNum.prototype).forEach(function (name) {
     BigNum[name] = function (num) {
         var args = [].slice.call(arguments, 1);
 
-        if (num instanceof BigNum) {
+        if (BigNum.isBigNum(num)) {
             return num[name].apply(num, args);
         }
         else {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,15 @@ BigNum.conditionArgs = function(num, base) {
 cc.setJSConditioner(BigNum.conditionArgs);
 
 BigNum.isBigNum = function(num) {
-    return Boolean(num && num.badd && num.bsub && num.bmul && num.bdiv && num.bmod);
+    if (!num) {
+        return false;
+    }
+    for(var key in BigNum.prototype) {
+        if (!num[key]) {
+            return false;
+        }
+    }
+    return true;
 };
 
 BigNum.prototype.inspect = function () {

--- a/test/isbignum.js
+++ b/test/isbignum.js
@@ -1,16 +1,16 @@
 var assert = require('assert');
-var bignum = require('../');
+var BigNum = require('../');
 
 exports.create = function () {
 
-    var validBn = bignum('42');
+    var validBn = BigNum('42');
     var testObj;
 
-    testObj = bignum('123');
-    assert.equal(bignum.isBigNum(testObj), true);
+    testObj = BigNum('123');
+    assert.equal(BigNum.isBigNum(testObj), true);
 
     testObj = {};
-    assert.equal(bignum.isBigNum(testObj), false);
+    assert.equal(BigNum.isBigNum(testObj), false);
 
     testObj = {};
     assert.throws(function() {
@@ -18,7 +18,7 @@ exports.create = function () {
     });
 
     testObj = falsePositive();
-    assert.equal(bignum.isBigNum(testObj), true);
+    assert.equal(BigNum.isBigNum(testObj), true);
 
     // this causes a hard crash, so its disabled for now
     // testObj = falsePositive();
@@ -28,13 +28,11 @@ exports.create = function () {
 };
 
 function falsePositive () {
-    return {
-        badd: true,
-        bsub: true,
-        bmul: true,
-        bdiv: true,
-        bmod: true,
-    };
+    var obj = {};
+    for (var key in BigNum.prototype) {
+        obj[key] = true;
+    }
+    return obj;
 }
 
 if (process.argv[1] === __filename) {

--- a/test/isbignum.js
+++ b/test/isbignum.js
@@ -1,0 +1,49 @@
+var assert = require('assert');
+var bignum = require('../');
+
+exports.create = function () {
+
+    var validBn = bignum('42');
+    var testObj;
+
+    testObj = bignum('123');
+    assert.equal(bignum.isBigNum(testObj), true);
+
+    testObj = {};
+    assert.equal(bignum.isBigNum(testObj), false);
+
+    testObj = {};
+    assert.throws(function() {
+        validBn.add(testObj)
+    });
+
+    testObj = falsePositive();
+    assert.equal(bignum.isBigNum(testObj), true);
+
+    // this causes a hard crash, so its disabled for now
+    // testObj = falsePositive();
+    // assert.throws(function() {
+    //     validBn.add(testObj)
+    // });
+};
+
+function falsePositive () {
+    return {
+        badd: true,
+        bsub: true,
+        bmul: true,
+        bdiv: true,
+        bmod: true,
+    };
+}
+
+if (process.argv[1] === __filename) {
+    assert.eql = assert.deepEqual;
+    Object.keys(exports).forEach(function (ex) {
+        exports[ex]();
+    });
+
+    if ("function" === typeof gc) {
+        gc();
+    }
+}


### PR DESCRIPTION
Fixes #41
> If my deps use two slightly different versions of bignum, we end up with two different instances of the BigNum class and they are not compatible b/c the instanceof checking fails here.
Another approach is to analyze an instance via a type checking method BigNum.isBigNum(num)

use of instanceof [here](https://github.com/justmoon/node-bignum/blob/0021dd78560ddfb7f83b0ff1da2ae4dfaa4d6a96/index.js#L73)