### PR TITLE
Upgrade nan to 1.8.4 (builds for io.js 2.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://www.justmoon.net"
   },
   "dependencies": {
-    "nan": "~1.6.2"
+    "nan": "^1.8.4"
   },
   "devDependencies": {
     "expresso": ">=0.6.0",


### PR DESCRIPTION
Upgrading nan fixes the build for io.js 2.0.0. Fixes #47.

Test Plan:
```
npm install && npm test

> bignum@0.9.2 test /Users/ide/Code/node-bignum
> expresso

   100% 33 tests
```