### PR TITLE
add support for prebuild to build for all abi version of node/iojs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /build
 
 node_modules
+prebuilds/

--- a/.prebuildrc
+++ b/.prebuildrc
@@ -1,0 +1,17 @@
+# abi 11
+target[] = 0.10.40
+
+# abi 14
+target[] = 0.12.7
+
+# abi 42
+target[] = 1.0.4
+
+# abi 43
+target[] = 1.8.4
+
+# abi 44
+target[] = 2.4.0
+
+# abi 45
+target[] = 3.0.0

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "url": "http://www.justmoon.net"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.0.0",
+    "prebuild": "^2.5.1"
   },
   "devDependencies": {
     "expresso": ">=0.6.0",
@@ -34,8 +35,9 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node-gyp configure build",
-    "test": "expresso"
+    "install": "prebuild --download",
+    "test": "expresso",
+    "prebuild": "prebuild --strip"
   },
   "contributors": [
     "James Halliday <mail@substack.net>"


### PR DESCRIPTION
![prebuild-node-bignum](https://cloud.githubusercontent.com/assets/308049/9718501/a3b2aab4-557c-11e5-8a2a-b4b5373b2645.png)

Also allows you to create releases on github and publishing the prebuilt binaries there, see https://github.com/Level/leveldown/releases/tag/v1.4.1 as example
