### PR TITLE
Add arm64 architecture - assume that aarch64 is what we want to point…

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -70,6 +70,13 @@
                 }
               ],
               [
+                'target_arch=="arm64"', {
+                  'variables': {
+                    'openssl_config_path': '<(nodedir)/deps/openssl/config/aarch64'
+                  }
+                },
+              ],
+              [
                 'target_arch=="ppc64"', {
                   'variables': {
                     'openssl_config_path': '<(nodedir)/deps/openssl/config/powerpc64'


### PR DESCRIPTION
… at - can't test, expresso is deprecated and won't install with npm.
Did run the examples successfully, however, so I'm pretty confident that this fix works.
People seem to be reporting this bug at homebridge (which is how I came here)