### PR TITLE
Update binary path directly to Github 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "test": "standard && tap --timeout 120 test/*.js"
   },
   "binary": {
-    "host": "https://rvagg-node.s3-us-west-2.amazonaws.com",
+    "host": "https://github.com/justmoon",
     "module_name": "bignum",
     "module_path": "binding/",
-    "remote_path": "./{name}/v{version}"
+    "remote_path": "./node-{name}/archive/v{version}"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Because the Amazon server respo…nds with a 403 error
Update remote path accordingly