### PR TITLE
Makes modular exponentiation constant time by default.

### DIFF
--- a/bignum.cc
+++ b/bignum.cc
@@ -682,8 +682,9 @@ NAN_METHOD(BigNum::Bpowm)
   BigNum *bn1 = Nan::ObjectWrap::Unwrap<BigNum>(info[0]->ToObject(info.GetIsolate()->GetCurrentContext()).ToLocalChecked());
   BigNum *bn2 = Nan::ObjectWrap::Unwrap<BigNum>(info[1]->ToObject(info.GetIsolate()->GetCurrentContext()).ToLocalChecked());
   BigNum *res = new BigNum();
-  
-  BN_set_flags(bn1->bignum_, BN_FLG_CONSTTIME);
+  // Constant-time flag only supported for odd modulus
+  if (BN_is_odd(bn2->bignum_))
+    BN_set_flags(bn1->bignum_, BN_FLG_CONSTTIME);
   BN_mod_exp(res->bignum_, bignum->bignum_, bn1->bignum_, bn2->bignum_, ctx);
 
   WRAP_RESULT(res, result);
@@ -701,8 +702,9 @@ NAN_METHOD(BigNum::Upowm)
   BigNum *exp = new BigNum(x);
 
   BigNum *res = new BigNum();
-
-  BN_set_flags(exp->bignum_, BN_FLG_CONSTTIME);
+  // Constant-time flag only supported for odd modulus
+  if (BN_is_odd(bn->bignum_))
+    BN_set_flags(exp->bignum_, BN_FLG_CONSTTIME);
   BN_mod_exp(res->bignum_, bignum->bignum_, exp->bignum_, bn->bignum_, ctx);
 
   WRAP_RESULT(res, result);

--- a/bignum.cc
+++ b/bignum.cc
@@ -682,6 +682,8 @@ NAN_METHOD(BigNum::Bpowm)
   BigNum *bn1 = Nan::ObjectWrap::Unwrap<BigNum>(info[0]->ToObject(info.GetIsolate()->GetCurrentContext()).ToLocalChecked());
   BigNum *bn2 = Nan::ObjectWrap::Unwrap<BigNum>(info[1]->ToObject(info.GetIsolate()->GetCurrentContext()).ToLocalChecked());
   BigNum *res = new BigNum();
+  
+  BN_set_flags(bn1->bignum_, BN_FLG_CONSTTIME);
   BN_mod_exp(res->bignum_, bignum->bignum_, bn1->bignum_, bn2->bignum_, ctx);
 
   WRAP_RESULT(res, result);
@@ -699,6 +701,8 @@ NAN_METHOD(BigNum::Upowm)
   BigNum *exp = new BigNum(x);
 
   BigNum *res = new BigNum();
+
+  BN_set_flags(exp->bignum_, BN_FLG_CONSTTIME);
   BN_mod_exp(res->bignum_, bignum->bignum_, exp->bignum_, bn->bignum_, ctx);
 
   WRAP_RESULT(res, result);


### PR DESCRIPTION
Calling BN_mod_exp with a small base, and no constant time flag fallback on an insecure implementation with OpenSSL. If the exponent is related to a secret value, the resulting leakage may compromise the secret.
A simple fix is to set the appropriate flag before computing the modular exponentiation.